### PR TITLE
Elevator Sys ID

### DIFF
--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
@@ -146,6 +146,7 @@ public class RobotConfig {
     VisionControls.addGUI(vision, driverTab);
 
     ElevatorControls.setupController(elevator, mainController);
+    ElevatorControls.addSysId(elevator);
 
     ArmControls.setupController(arm, mainController);
 

--- a/src/main/java/frc/robot/subsystems/controls/elevator/ElevatorControls.java
+++ b/src/main/java/frc/robot/subsystems/controls/elevator/ElevatorControls.java
@@ -1,8 +1,10 @@
 package frc.robot.subsystems.controls.elevator;
 
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.subsystems.interfaces.Elevator;
 
 public class ElevatorControls {
@@ -40,5 +42,16 @@ public class ElevatorControls {
                     elevator.runVoltage(0.0);
                   }
                 }));
+  }
+
+  public static void addSysId(Elevator elevator) {
+    SmartDashboard.putData(
+        "Elevator Dynamic Forward", elevator.sysIdDynamic(SysIdRoutine.Direction.kForward));
+    SmartDashboard.putData(
+        "Elevator Dynamic Reverse", elevator.sysIdDynamic(SysIdRoutine.Direction.kReverse));
+    SmartDashboard.putData(
+        "Elevator Quasistatic Forward", elevator.sysIdQuasistatic(SysIdRoutine.Direction.kForward));
+    SmartDashboard.putData(
+        "Elevator Quasistatic Reverse", elevator.sysIdQuasistatic(SysIdRoutine.Direction.kReverse));
   }
 }

--- a/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
@@ -1,8 +1,12 @@
 package frc.robot.subsystems.implementations.elevator;
 
+import static edu.wpi.first.units.Units.Volts;
+
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.io.interfaces.ElevatorIO;
 import frc.robot.io.interfaces.ElevatorIOInputsAutoLogged;
 import frc.robot.subsystems.interfaces.Elevator;
@@ -18,9 +22,20 @@ public class ElevatorSubsystem extends SubsystemBase implements Elevator {
   private final double elevatorLigament2doffset = 0.05;
 
   private double targetMeters = 0.0;
+  public static SysIdRoutine sysId;
 
   public ElevatorSubsystem(ElevatorIO io) {
     this.io = io;
+
+    // Configure SysId based on the AdvantageKit example
+    sysId =
+        new SysIdRoutine(
+            new SysIdRoutine.Config(
+                null,
+                null,
+                null,
+                (state) -> Logger.recordOutput("Elevator/SysIdState", state.toString())),
+            new SysIdRoutine.Mechanism((voltage) -> runVoltage(voltage.in(Volts)), null, this));
   }
 
   @Override
@@ -82,5 +97,15 @@ public class ElevatorSubsystem extends SubsystemBase implements Elevator {
   @Override
   public void setLigament(MechanismLigament2d ligament2d) {
     elevator2d = ligament2d;
+  }
+
+  @Override
+  public Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
+    return sysId.quasistatic(direction);
+  }
+
+  @Override
+  public Command sysIdDynamic(SysIdRoutine.Direction direction) {
+    return sysId.dynamic(direction);
   }
 }

--- a/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
@@ -26,15 +26,11 @@ public class ElevatorSubsystem extends SubsystemBase implements Elevator {
     this(io, null);
   }
 
-  public ElevatorSubsystem(ElevatorIO io, String name)
-  {
+  public ElevatorSubsystem(ElevatorIO io, String name) {
     this.io = io;
-    if (name != null)
-    {
+    if (name != null) {
       setName("Elevator(" + name + ")");
-    }
-    else
-    {
+    } else {
       setName("Elevator");
     }
 

--- a/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
@@ -1,7 +1,5 @@
 package frc.robot.subsystems.implementations.elevator;
 
-import static edu.wpi.first.units.Units.Volts;
-
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -22,20 +20,12 @@ public class ElevatorSubsystem extends SubsystemBase implements Elevator {
   private final double elevatorLigament2doffset = 0.05;
 
   private double targetMeters = 0.0;
-  public static SysIdRoutine sysId;
+  private SysIdRoutine sysId;
 
   public ElevatorSubsystem(ElevatorIO io) {
     this.io = io;
 
-    // Configure SysId based on the AdvantageKit example
-    sysId =
-        new SysIdRoutine(
-            new SysIdRoutine.Config(
-                null,
-                null,
-                null,
-                (state) -> Logger.recordOutput("Elevator/SysIdState", state.toString())),
-            new SysIdRoutine.Mechanism((voltage) -> runVoltage(voltage.in(Volts)), null, this));
+    sysId = createSystemIdRoutine("Elevator/SysIdState");
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/implementations/elevator/ElevatorSubsystem.java
@@ -20,18 +20,31 @@ public class ElevatorSubsystem extends SubsystemBase implements Elevator {
   private final double elevatorLigament2doffset = 0.05;
 
   private double targetMeters = 0.0;
-  private SysIdRoutine sysId;
+  private final SysIdRoutine sysId;
 
   public ElevatorSubsystem(ElevatorIO io) {
-    this.io = io;
+    this(io, null);
+  }
 
-    sysId = createSystemIdRoutine("Elevator/SysIdState");
+  public ElevatorSubsystem(ElevatorIO io, String name)
+  {
+    this.io = io;
+    if (name != null)
+    {
+      setName("Elevator(" + name + ")");
+    }
+    else
+    {
+      setName("Elevator");
+    }
+
+    sysId = createSystemIdRoutine(getName());
   }
 
   @Override
   public void periodic() {
     io.updateInputs(inputs);
-    Logger.processInputs("Elevator", inputs);
+    Logger.processInputs(getName(), inputs);
 
     if (null != elevator2d) {
       elevator2d.setLength(

--- a/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
@@ -64,7 +64,10 @@ public interface Elevator extends Subsystem {
   public default SysIdRoutine createSystemIdRoutine(String subsystemName) {
     return new SysIdRoutine(
         new SysIdRoutine.Config(
-            null, null, null, (state) -> Logger.recordOutput(subsystemName + "/SysIdState", state.toString())),
+            null,
+            null,
+            null,
+            (state) -> Logger.recordOutput(subsystemName + "/SysIdState", state.toString())),
         new SysIdRoutine.Mechanism((voltage) -> runVoltage(voltage.in(Volts)), null, this));
   }
 

--- a/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
@@ -1,7 +1,10 @@
 package frc.robot.subsystems.interfaces;
 
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 
 public interface Elevator extends Subsystem {
   public static class Constants {
@@ -54,4 +57,14 @@ public interface Elevator extends Subsystem {
 
   public default void setLigament(MechanismLigament2d ligament2d) {}
   ;
+
+  /** Returns a command to run a quasistatic test in the specified direction. */
+  public default Command sysIdQuasistatic(SysIdRoutine.Direction direction) {
+    return new InstantCommand();
+  }
+
+  /** Returns a command to run a dynamic test in the specified direction. */
+  public default Command sysIdDynamic(SysIdRoutine.Direction direction) {
+    return new InstantCommand();
+  }
 }

--- a/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
@@ -1,10 +1,13 @@
 package frc.robot.subsystems.interfaces;
 
+import static edu.wpi.first.units.Units.Volts;
+
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
+import org.littletonrobotics.junction.Logger;
 
 public interface Elevator extends Subsystem {
   public static class Constants {
@@ -57,6 +60,13 @@ public interface Elevator extends Subsystem {
 
   public default void setLigament(MechanismLigament2d ligament2d) {}
   ;
+
+  public default SysIdRoutine createSystemIdRoutine(String subsystemName) {
+    return new SysIdRoutine(
+        new SysIdRoutine.Config(
+            null, null, null, (state) -> Logger.recordOutput(subsystemName, state.toString())),
+        new SysIdRoutine.Mechanism((voltage) -> runVoltage(voltage.in(Volts)), null, this));
+  }
 
   /** Returns a command to run a quasistatic test in the specified direction. */
   public default Command sysIdQuasistatic(SysIdRoutine.Direction direction) {

--- a/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/interfaces/Elevator.java
@@ -64,7 +64,7 @@ public interface Elevator extends Subsystem {
   public default SysIdRoutine createSystemIdRoutine(String subsystemName) {
     return new SysIdRoutine(
         new SysIdRoutine.Config(
-            null, null, null, (state) -> Logger.recordOutput(subsystemName, state.toString())),
+            null, null, null, (state) -> Logger.recordOutput(subsystemName + "/SysIdState", state.toString())),
         new SysIdRoutine.Mechanism((voltage) -> runVoltage(voltage.in(Volts)), null, this));
   }
 


### PR DESCRIPTION
This is the sample Elevator Sys Id implementation.  The basic steps are:

1. Run the simulation/robot
2. There are 4 Elevator SysID commands added to the SmartDashboard network table entry
   1. Dynamic Forward
   2. Dynamic Reverse
   3. Quasistatic Forward
   4. Quasistatic Reverse
3. Add these commands to Shuffleboard/SmartDashboard/Elastic
   * ![image](https://github.com/user-attachments/assets/59da51c3-6247-44f5-a933-79f19064e0aa)
4. Put the simulation/robot in "teleop" mode
5. Run each of the commands sequentially until the mechanism reaches it's max/min physical limits
6. Disable the simulation/robot
7. Retrieve the AdvantageKit (`akit_xxx.wpilog`) log file
   1. In simulation, it's written to the project root directory
   2. On the robot, it's written to the thumbdrive
9. Load the log into AdvantageScope and then export/expand. See: https://docs.advantagekit.org/data-flow/sysid-compatibility/#loading-data
10. Load the exported log into the `SysId` tool
   * ![image](https://github.com/user-attachments/assets/d698f601-8549-430c-9fb3-728050687ede)
11. Select the Data
   * Test State: Drag "RealOutputs-->Elevator-->SysIdState"
   * Analysis Type: "Elevator"
   * Velocity: Drag "Elevator-->VelocityInMetersPerSecond"
   * Position: Drag "Elevator-->PositionMeters"
   * Voltage: Drag "Elevator-->AppliedVolts"
13. Double check units is "Meters"
   * ![image](https://github.com/user-attachments/assets/e3876953-080e-4a40-94ed-6d8c43b7ce96)
14. Click "Load"
15. See the Feedforward and PID values
   * ![image](https://github.com/user-attachments/assets/93874d32-c53e-4d60-adfe-4f6a70b75754)