### PR TITLE
Removing stub logic.  Everything will be a stub unless it is explicitly defined in the game-specific RobotConfig class.

### DIFF
--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
@@ -56,9 +56,7 @@ public class RobotConfig {
   // private final ShuffleboardTab debugTab = Shuffleboard.getTab("Debug");
   // private final ShuffleboardTab sysIdTestTab = Shuffleboard.getTab("SysId");
 
-  public RobotConfig() {
-
-  }
+  public RobotConfig() {}
 
   private void checkSubsystemsInitialized() {
     if (drive == null) {

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
@@ -55,84 +56,83 @@ public class RobotConfig {
   // private final ShuffleboardTab debugTab = Shuffleboard.getTab("Debug");
   // private final ShuffleboardTab sysIdTestTab = Shuffleboard.getTab("SysId");
 
-  public RobotConfig(boolean stubDrive, boolean stubAuto, boolean stubVision) {
-    this(stubDrive, stubAuto, stubVision, true, true, true);
-  }
-
-  public RobotConfig(
-      boolean stubDrive,
-      boolean stubAuto,
-      boolean stubVision,
-      boolean stubElevator,
-      boolean stubArm) {
-    this(stubDrive, stubAuto, stubVision, stubElevator, stubArm, true);
-  }
-
   public RobotConfig() {
-    this(true, true, true, true, true, true);
-  }
 
-  public RobotConfig(
-      boolean stubDrive,
-      boolean stubAuto,
-      boolean stubVision,
-      boolean stubElevator,
-      boolean stubArm,
-      boolean stubAlgaeSubsystem) {
-    if (stubDrive) {
-      drive = new DriveBase();
-    }
+    // Initialize subsystem that does not do aything.
+    // Initialize subsystem in derived robot config classes
+    drive = new DriveBase();
 
-    if (stubAuto) {
-      autoChooser = new SendableChooser<>();
-      autoChooser.setDefaultOption("No Auto Routines Specified", Commands.none());
-    }
+    // Initialize subsystem that does not do aything.
+    // Initialize subsystem in derived robot config classes
+    autoChooser = new SendableChooser<>();
+    autoChooser.setDefaultOption("No Auto Routines Specified", Commands.none());
 
+    // Initialize subsystem that does not do aything.
+    // Initialize subsystem in derived robot config classes
+    elevator = new ElevatorSubsystem(new ElevatorIOStub());
+
+    // Initialize subsystem that does not do aything.
+    // Initialize subsystem in derived robot config classes
+    arm =
+        new ArmSubsystem(
+            new ArmIOStub(Arm.Constants.maxAngleInDegrees, Arm.Constants.minAngleInDegrees));
+
+    algaeSubsystem =
+        new AlgaeSubsystem(
+            new IntakeIOStub(),
+            new ArmIOStub(Algae.Constants.maxArmAngleDegrees, Algae.Constants.minArmAngleDegrees));
+
+    // Initialize subsystem that does not do aything.
+    // Initialize subsystem in derived robot config classes
     vision = new VisionSubsystem(AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape));
 
-    if (stubVision) {
-      if (Robot.isSimulation()) {
-        vision.addCamera(
-            new Camera(
-                "photonvision",
-                new Transform3d(
-                    new Translation3d(-0.221, 0, .164),
-                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(180)))));
-        vision.addCamera(
-            new Camera(
-                "left",
-                new Transform3d(
-                    new Translation3d(0, 0.221, .164),
-                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(90)))));
-        vision.addCamera(
-            new Camera(
-                "right",
-                new Transform3d(
-                    new Translation3d(0, -0.221, .164),
-                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(-90)))));
-      }
+    if (Robot.isSimulation()) {
+      vision.addCamera(
+          new Camera(
+              "photonvision",
+              new Transform3d(
+                  new Translation3d(-0.221, 0, .164),
+                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(180)))));
+      vision.addCamera(
+          new Camera(
+              "left",
+              new Transform3d(
+                  new Translation3d(0, 0.221, .164),
+                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(90)))));
+      vision.addCamera(
+          new Camera(
+              "right",
+              new Transform3d(
+                  new Translation3d(0, -0.221, .164),
+                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(-90)))));
     }
+  }
 
-    if (stubElevator) {
-      elevator = new ElevatorSubsystem(new ElevatorIOStub());
+  private void checkSubsystemsInitialized() {
+    if (drive == null) {
+      DriverStation.reportError("Drive subsystem is not initialized.", false);
     }
-
-    if (stubArm) {
-      arm =
-          new ArmSubsystem(
-              new ArmIOStub(Arm.Constants.maxAngleInDegrees, Arm.Constants.minAngleInDegrees));
+    if (vision == null) {
+      DriverStation.reportError("Vision subsystem is not initialized.", false);
     }
-
-    if (stubAlgaeSubsystem) {
-      algaeSubsystem =
-          new AlgaeSubsystem(
-              new IntakeIOStub(),
-              new ArmIOStub(
-                  Algae.Constants.maxArmAngleDegrees, Algae.Constants.minArmAngleDegrees));
+    if (elevator == null) {
+      DriverStation.reportError("Elevator subsystem is not initialized.", false);
+    }
+    if (arm == null) {
+      DriverStation.reportError("Arm subsystem is not initialized.", false);
+    }
+    if (algaeSubsystem == null) {
+      DriverStation.reportError("Algae subsystem is not initialized.", false);
+    }
+    if (autoChooser == null) {
+      DriverStation.reportError("Auto chooser is not initialized.", false);
     }
   }
 
   public void configureBindings() {
+
+    checkSubsystemsInitialized();
+
     if (Robot.isSimulation()) {
       vision.enableSimulation(() -> RobotConfig.drive.getPose(), true);
     }

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
@@ -58,74 +58,73 @@ public class RobotConfig {
 
   public RobotConfig() {
 
-    // Initialize subsystem that does not do aything.
-    // Initialize subsystem in derived robot config classes
-    drive = new DriveBase();
-
-    // Initialize subsystem that does not do aything.
-    // Initialize subsystem in derived robot config classes
-    autoChooser = new SendableChooser<>();
-    autoChooser.setDefaultOption("No Auto Routines Specified", Commands.none());
-
-    // Initialize subsystem that does not do aything.
-    // Initialize subsystem in derived robot config classes
-    elevator = new ElevatorSubsystem(new ElevatorIOStub());
-
-    // Initialize subsystem that does not do aything.
-    // Initialize subsystem in derived robot config classes
-    arm =
-        new ArmSubsystem(
-            new ArmIOStub(Arm.Constants.maxAngleInDegrees, Arm.Constants.minAngleInDegrees));
-
-    algaeSubsystem =
-        new AlgaeSubsystem(
-            new IntakeIOStub(),
-            new ArmIOStub(Algae.Constants.maxArmAngleDegrees, Algae.Constants.minArmAngleDegrees));
-
-    // Initialize subsystem that does not do aything.
-    // Initialize subsystem in derived robot config classes
-    vision = new VisionSubsystem(AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape));
-
-    if (Robot.isSimulation()) {
-      vision.addCamera(
-          new Camera(
-              "photonvision",
-              new Transform3d(
-                  new Translation3d(-0.221, 0, .164),
-                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(180)))));
-      vision.addCamera(
-          new Camera(
-              "left",
-              new Transform3d(
-                  new Translation3d(0, 0.221, .164),
-                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(90)))));
-      vision.addCamera(
-          new Camera(
-              "right",
-              new Transform3d(
-                  new Translation3d(0, -0.221, .164),
-                  new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(-90)))));
-    }
   }
 
   private void checkSubsystemsInitialized() {
     if (drive == null) {
       DriverStation.reportError("Drive subsystem is not initialized.", false);
+      // Initialize subsystem that does not do aything.
+      // Initialize subsystem in derived robot config classes
+      drive = new DriveBase();
     }
-    if (vision == null) {
-      DriverStation.reportError("Vision subsystem is not initialized.", false);
-    }
+
     if (elevator == null) {
       DriverStation.reportError("Elevator subsystem is not initialized.", false);
+      // Initialize subsystem that does not do aything.
+      // Initialize subsystem in derived robot config classes
+      elevator = new ElevatorSubsystem(new ElevatorIOStub());
     }
+
     if (arm == null) {
       DriverStation.reportError("Arm subsystem is not initialized.", false);
+      arm =
+          new ArmSubsystem(
+              new ArmIOStub(Arm.Constants.maxAngleInDegrees, Arm.Constants.minAngleInDegrees));
     }
+
     if (algaeSubsystem == null) {
       DriverStation.reportError("Algae subsystem is not initialized.", false);
+      algaeSubsystem =
+          new AlgaeSubsystem(
+              new IntakeIOStub(),
+              new ArmIOStub(
+                  Algae.Constants.maxArmAngleDegrees, Algae.Constants.minArmAngleDegrees));
     }
+
     if (autoChooser == null) {
       DriverStation.reportError("Auto chooser is not initialized.", false);
+      // Initialize subsystem that does not do aything.
+      // Initialize subsystem in derived robot config classes
+      autoChooser = new SendableChooser<>();
+      autoChooser.setDefaultOption("No Auto Routines Specified", Commands.none());
+    }
+
+    if (vision == null) {
+      DriverStation.reportError("Vision subsystem is not initialized.", false);
+      // Initialize subsystem that does not do aything.
+      // Initialize subsystem in derived robot config classes
+      vision = new VisionSubsystem(AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape));
+
+      if (Robot.isSimulation()) {
+        vision.addCamera(
+            new Camera(
+                "photonvision",
+                new Transform3d(
+                    new Translation3d(-0.221, 0, .164),
+                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(180)))));
+        vision.addCamera(
+            new Camera(
+                "left",
+                new Transform3d(
+                    new Translation3d(0, 0.221, .164),
+                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(90)))));
+        vision.addCamera(
+            new Camera(
+                "right",
+                new Transform3d(
+                    new Translation3d(0, -0.221, .164),
+                    new Rotation3d(0, Units.degreesToRadians(-20), Units.degreesToRadians(-90)))));
+      }
     }
   }
 

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfig.java
@@ -62,28 +62,28 @@ public class RobotConfig {
 
   private void checkSubsystemsInitialized() {
     if (drive == null) {
-      DriverStation.reportError("Drive subsystem is not initialized.", false);
+      DriverStation.reportWarning("Drive subsystem is not initialized.", true);
       // Initialize subsystem that does not do aything.
       // Initialize subsystem in derived robot config classes
       drive = new DriveBase();
     }
 
     if (elevator == null) {
-      DriverStation.reportError("Elevator subsystem is not initialized.", false);
+      DriverStation.reportWarning("Elevator subsystem is not initialized.", true);
       // Initialize subsystem that does not do aything.
       // Initialize subsystem in derived robot config classes
       elevator = new ElevatorSubsystem(new ElevatorIOStub());
     }
 
     if (arm == null) {
-      DriverStation.reportError("Arm subsystem is not initialized.", false);
+      DriverStation.reportWarning("Arm subsystem is not initialized.", true);
       arm =
           new ArmSubsystem(
               new ArmIOStub(Arm.Constants.maxAngleInDegrees, Arm.Constants.minAngleInDegrees));
     }
 
     if (algaeSubsystem == null) {
-      DriverStation.reportError("Algae subsystem is not initialized.", false);
+      DriverStation.reportWarning("Algae subsystem is not initialized.", true);
       algaeSubsystem =
           new AlgaeSubsystem(
               new IntakeIOStub(),
@@ -92,7 +92,7 @@ public class RobotConfig {
     }
 
     if (autoChooser == null) {
-      DriverStation.reportError("Auto chooser is not initialized.", false);
+      DriverStation.reportWarning("Auto chooser is not initialized.", true);
       // Initialize subsystem that does not do aything.
       // Initialize subsystem in derived robot config classes
       autoChooser = new SendableChooser<>();
@@ -100,7 +100,7 @@ public class RobotConfig {
     }
 
     if (vision == null) {
-      DriverStation.reportError("Vision subsystem is not initialized.", false);
+      DriverStation.reportWarning("Vision subsystem is not initialized.", true);
       // Initialize subsystem that does not do aything.
       // Initialize subsystem in derived robot config classes
       vision = new VisionSubsystem(AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape));

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigNemo.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigNemo.java
@@ -7,7 +7,7 @@ import frc.robot.subsystems.interfaces.Drive;
 /* Override Nemo specific constants here */
 public class RobotConfigNemo extends RobotConfig {
   public RobotConfigNemo() {
-    super(false, true, true);
+    super();
 
     // Nemo has a Swerve drive train
     Drive.Constants.rotatePidKp = 0.025;

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigPhoenix.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigPhoenix.java
@@ -12,8 +12,7 @@ import frc.robot.subsystems.interfaces.Vision.Camera;
 /* Override Phoenix specific constants here */
 public class RobotConfigPhoenix extends RobotConfig {
   public RobotConfigPhoenix() {
-    super(false, true, false, true, true, true);
-
+    super();
     // Phoenix has a Swerve drive train
     Drive.Constants.rotatePidKp = 0.025;
     Drive.Constants.rotatePidKi = 0.0;

--- a/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigStub.java
+++ b/src/main/java/frc/robot/config/game/reefscape2025/RobotConfigStub.java
@@ -14,8 +14,7 @@ public class RobotConfigStub extends RobotConfig {
   GizmoSubsystem gizmo;
 
   public RobotConfigStub() {
-    super(false, true, true);
-
+    super();
     drive = new DriveSwerveYAGSL("yagsl/stub");
     if (Robot.isSimulation()) {
       drive.setPose(new Pose2d(new Translation2d(1, 1), new Rotation2d()));


### PR DESCRIPTION
This logic eliminates the need for the "stubSubsystem" booleans being passed into the base RobotConfig class.  This change forces initialization of desired subsystems in the derived robotConfig<Robot> logic for each robot where <Robot> is the name of the robot being configured.  If a subsystem is not initialized a warning will be logged and a basic 'stub' version of the class will be initialized.